### PR TITLE
Add unit tests for the backplane

### DIFF
--- a/UFX.Orleans.SignalRBackplane.sln
+++ b/UFX.Orleans.SignalRBackplane.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UFX.Orleans.SignalRBackplan
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A54D4A25-49FE-462A-B6ED-F6F65724C661}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UFX.Orleans.SignalRBackplane.Tests", "tests\UFX.Orleans.SignalRBackplane.Tests\UFX.Orleans.SignalRBackplane.Tests.csproj", "{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{B97FCC8A-0D17-4B5E-9204-524F163DB285}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B97FCC8A-0D17-4B5E-9204-524F163DB285}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B97FCC8A-0D17-4B5E-9204-524F163DB285}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,6 +79,7 @@ Global
 		{A5E219A6-462D-4298-9C11-6B4DEEEC39AB} = {D024B03D-C935-42D7-996D-DC72205E7B36}
 		{E0EEC42E-E9A9-4884-AB6E-5E9E3B186379} = {D024B03D-C935-42D7-996D-DC72205E7B36}
 		{B97FCC8A-0D17-4B5E-9204-524F163DB285} = {A54D4A25-49FE-462A-B6ED-F6F65724C661}
+		{2E5F1003-7E69-4EEC-A469-8FF1A7E4F2FA} = {A54D4A25-49FE-462A-B6ED-F6F65724C661}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DA41F210-CF4A-4050-9900-D794112D87C6}

--- a/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
@@ -15,10 +15,12 @@ internal class ConnectionGrain : SignalrBaseGrain, IConnectionGrain, IConnection
 {
     public ConnectionGrain(
         [PersistentState(Constants.StateName, Constants.StorageName)] IPersistentState<SubscriptionState> persistedSubs,
+        IGrainContext grainContext,
+        IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
         ILogger<ConnectionGrain> logger
     )
-        : base(persistedSubs, options, logger)
+        : base(persistedSubs, grainContext, reminderResolver, options, logger)
     {
     }
 

--- a/src/UFX.Orleans.SignalRBackplane/Grains/GroupGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/GroupGrain.cs
@@ -13,23 +13,29 @@ internal interface IGroupGrainInternal : ISignalrGrain
 
 internal class GroupGrain : SignalrBaseGrain, IGroupGrain, IGroupGrainInternal
 {
+    private readonly IGrainFactory _grainFactory;
+
     public GroupGrain(
         [PersistentState(Constants.StateName, Constants.StorageName)] IPersistentState<SubscriptionState> persistedSubs,
+        IGrainContext grainContext,
+        IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
-        ILogger<GroupGrain> logger
+        ILogger<GroupGrain> logger,
+        IGrainFactory grainFactory
     )
-        : base(persistedSubs, options, logger)
+        : base(persistedSubs, grainContext, reminderResolver, options, logger)
     {
+        _grainFactory = grainFactory;
     }
 
     public Task AddToGroupAsync(string connectionId) 
-        => GrainFactory
+        => _grainFactory
             .GetConnectionGrain(HubName, connectionId)
             .AsReference<IConnectionGrainInternal>()
             .AddToGroupAsync(EntityId);
 
     public Task RemoveFromGroupAsync(string connectionId)
-        => GrainFactory
+        => _grainFactory
             .GetConnectionGrain(HubName, connectionId)
             .AsReference<IConnectionGrainInternal>()
             .RemoveFromGroupAsync(EntityId);

--- a/src/UFX.Orleans.SignalRBackplane/Grains/HubGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/HubGrain.cs
@@ -9,10 +9,12 @@ internal class HubGrain : SignalrBaseGrain, IHubGrain
 {
     public HubGrain(
         [PersistentState(Constants.StateName, Constants.StorageName)] IPersistentState<SubscriptionState> persistedSubs,
+        IGrainContext grainContext,
+        IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
         ILogger<HubGrain> logger
     )
-        : base(persistedSubs, options, logger)
+        : base(persistedSubs, grainContext, reminderResolver, options, logger)
     {
     }
 

--- a/src/UFX.Orleans.SignalRBackplane/Grains/UserGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/UserGrain.cs
@@ -9,9 +9,11 @@ internal class UserGrain : SignalrBaseGrain, IUserGrain
 {
     public UserGrain(
         [PersistentState(Constants.StateName, Constants.StorageName)] IPersistentState<SubscriptionState> persistedSubs,
+        IGrainContext grainContext,
+        IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
         ILogger<UserGrain> logger)
-        : base(persistedSubs, options, logger)
+        : base(persistedSubs, grainContext, reminderResolver, options, logger)
     {
     }
 

--- a/src/UFX.Orleans.SignalRBackplane/ReminderResolver.cs
+++ b/src/UFX.Orleans.SignalRBackplane/ReminderResolver.cs
@@ -1,0 +1,18 @@
+﻿using Orleans.Runtime;
+
+namespace UFX.Orleans.SignalRBackplane;
+
+internal interface IReminderResolver
+{
+    Task<IGrainReminder> GetReminder(IGrainBase grainBase, string reminderName);
+}
+
+/// <summary>
+/// An implementation of <see cref="IReminderResolver"/> that follows the same code path that calling this.GetReminder() would use in a grain.
+/// This exists so that we can mock it out in tests.
+/// </summary>
+internal class ReminderResolver : IReminderResolver
+{
+    public Task<IGrainReminder> GetReminder(IGrainBase grainBase, string reminderName) 
+        => grainBase.GetReminder(reminderName);
+}

--- a/src/UFX.Orleans.SignalRBackplane/SiloBuilderExtensions.cs
+++ b/src/UFX.Orleans.SignalRBackplane/SiloBuilderExtensions.cs
@@ -18,7 +18,9 @@ public static class SiloBuilderExtensions
             services.ConfigureOptions<SignalrOrleansOptions>();
         }
 
-        services.AddSingleton(typeof(HubLifetimeManager<>), typeof(OrleansHubLifetimeManager<>));
+        services
+            .AddSingleton(typeof(HubLifetimeManager<>), typeof(OrleansHubLifetimeManager<>))
+            .AddSingleton<IReminderResolver, ReminderResolver>();
 
         siloBuilder.AddReminders();
 

--- a/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
+++ b/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
@@ -17,4 +17,13 @@
     <ProjectReference Include="..\UFX.Orleans.SignalRBackplane.Abstractions\UFX.Orleans.SignalRBackplane.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>UFX.Orleans.SignalRBackplane.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/SignalrBaseGrainTests.cs
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/SignalrBaseGrainTests.cs
@@ -1,0 +1,250 @@
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using UFX.Orleans.SignalRBackplane.Grains;
+
+namespace UFX.Orleans.SignalRBackplane.Tests
+{
+    public class SignalrBaseGrainTests
+    {
+        [Fact]
+        public async Task Subscribe_AddsObserverToState_IfNotAlreadySubscribed()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+
+            var grain = new TestGrain(persistentState, grainContext);
+
+            // Act
+            await grain.SubscribeAsync(A.Fake<IHubLifetimeManagerGrainObserver>());
+
+            // Assert
+            persistentState.State.Observers.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Subscribe_DoesNotAddObserverToState_IfAlreadySubscribed()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+
+            var grain = new TestGrain(persistentState, grainContext);
+
+            // Act
+            var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer);
+            await grain.SubscribeAsync(observer);
+
+            // Assert
+            persistentState.State.Observers.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Unsubscribe_RemovesObserverFromState_IfAlreadySubscribed()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+
+            var grain = new TestGrain(persistentState, grainContext);
+
+            var observer1 = A.Fake<IHubLifetimeManagerGrainObserver>();
+            var observer2 = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer1);
+            await grain.SubscribeAsync(observer2);
+
+            // Act
+            await grain.UnsubscribeAsync(observer1);
+
+            // Assert
+            persistentState.State.Observers.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Unsubscribe_DeactivatesGrain_WhenLastObserverUnsubscribes()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+            
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+            
+            var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer);
+            
+            // Act
+            await grain.UnsubscribeAsync(observer);
+
+            // Assert
+            A.CallTo(() => grainContext.Deactivate(new(DeactivationReasonCode.ApplicationRequested, "DeactivateOnIdle was called."), null)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Unsubscribe_DoesNotDeactivateGrain_WhenSecondLastObserverUnsubscribes()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+
+            var observer1 = A.Fake<IHubLifetimeManagerGrainObserver>();
+            var observer2 = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer1);
+            await grain.SubscribeAsync(observer2);
+
+            // Act
+            await grain.UnsubscribeAsync(observer1);
+
+            // Assert
+            A.CallTo(() => grainContext.Deactivate(A<DeactivationReason>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public async Task NotifyAllObserversAsync_RemovesObserver_WhenNotificationFails()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+
+            var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer);
+
+            // Act
+            A.CallTo(() => observer.PingAsync()).Throws(new Exception());
+            await grain.ReceiveReminder("PingReminderName", new TickStatus());
+
+            // Assert
+            persistentState.State.Observers.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task NotifyAllObserversAsync_DoesNotRemoveObserver_WhenNotificationSucceeds()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "a"));
+            A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored)).Returns<IGrainReminder>(null!);
+
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+
+            var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+            await grain.SubscribeAsync(observer);
+
+            // Act
+            await grain.ReceiveReminder("PingReminderName", new TickStatus());
+
+            // Assert
+            persistentState.State.Observers.Should().HaveCount(1).And.Contain(observer);
+        }
+
+        [Fact]
+        public void HubAndEntityNames_AreCorrect_WhenGrainHasNoEntityIdInKey()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+
+            const string hubName = "hub.name";
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", hubName));
+
+            // Act
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+
+            // Assert
+            grain.TestGrainHubName.Should().Be(hubName);
+            grain.TestGrainEntityId.Should().Be(hubName);
+        }
+
+        [Fact]
+        public void HubAndEntityNames_AreCorrect_WhenGrainHasEntityIdInKey()
+        {
+            // Arrange
+            var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+            var grainContext = A.Fake<IGrainContext>();
+            var reminderResolver = A.Fake<IReminderResolver>();
+
+            const string hubName = "hub.name";
+            const string entityId = "entity.id";
+            A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", $"{hubName}/{entityId}"));
+
+            // Act
+            var grain = new TestGrain(
+                persistentState,
+                grainContext,
+                reminderResolver
+            );
+
+            // Assert
+            grain.TestGrainHubName.Should().Be(hubName);
+            grain.TestGrainEntityId.Should().Be(entityId);
+        }
+
+        private class TestGrain : SignalrBaseGrain
+        {
+            public string TestGrainHubName => HubName;
+            public string TestGrainEntityId => EntityId;
+
+            public TestGrain(IPersistentState<SubscriptionState> persistedSubs, IGrainContext grainContext)
+                : base(persistedSubs, grainContext, A.Fake<IReminderResolver>(), A.Fake<IOptions<SignalrOrleansOptions>>(), A.Fake<ILogger<SignalrBaseGrain>>())
+            {
+            }
+            
+            public TestGrain(
+                IPersistentState<SubscriptionState> persistedSubs, 
+                IGrainContext grainContext,
+                IReminderResolver reminderResolver) 
+                : base(persistedSubs, grainContext, reminderResolver, A.Fake<IOptions<SignalrOrleansOptions>>(), A.Fake<ILogger<SignalrBaseGrain>>())
+            {
+            }
+        }
+    }
+}

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/UFX.Orleans.SignalRBackplane.Tests.csproj
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/UFX.Orleans.SignalRBackplane.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UFX.Orleans.SignalRBackplane\UFX.Orleans.SignalRBackplane.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/Usings.cs
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
This involved injecting a service to get reminders, which uses the usual extension method in production code but can be mocked out in unit tests. 

Also changed the base grain to a POCO grain, implementing `IGrainBase` rather than `Grain`, so the grain context can be injected and mocked.