### PR TITLE
Add HasObserversAsync to IConnectionGrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,10 @@ The `IConnectionGrain` interface exposes a `HasObserversAsync()` method that act
 This is useful when you need to determine from outside the grain whether a particular connection is still live — for example, after a silo crash where the hub's `OnDisconnectedAsync` never completed and the grain still holds stale observer references. Instead of relying solely on the periodic cleanup ping, you can proactively query a stored connection ID at startup or on-demand:
 
 ```cs
-var connectionGrain = grainFactory.GetGrain<IConnectionGrain>($"myhubs.myhub/{connectionId}");
+// The grain key must match the backplane's own key format: "hubname/connectionId"
+// where hubName is typeof(THub).FullName!.ToLower()
+var hubName = typeof(MyHub).FullName!.ToLower(); // e.g. "myapp.hubs.myhub"
+var connectionGrain = grainFactory.GetGrain<IConnectionGrain>($"{hubName}/{connectionId}");
 bool isAlive = await connectionGrain.HasObserversAsync();
 ```
 

--- a/README.md
+++ b/README.md
@@ -291,9 +291,9 @@ If you would like to customise the cleanup period, use the `GrainCleanupPeriod` 
 ```
 
 ## Checking for Active Observers
-The `IConnectionGrain` interface exposes a `HasObserversAsync()` method that returns `true` if the connection grain currently has at least one active observer (i.e. a hub is subscribed to it), or `false` if the grain has no observers.
+The `IConnectionGrain` interface exposes a `HasObserversAsync()` method that actively pings the grain's current observers, prunes any that are no longer reachable, and then returns `true` if at least one live observer remains, or `false` if none do.
 
-This is useful when you need to determine from outside the grain whether a particular connection is still live — for example, after a silo crash where `UnregisterConnectionAsync` was never called. Instead of relying solely on the periodic cleanup ping, you can proactively query a stored connection ID at startup or on-demand:
+This is useful when you need to determine from outside the grain whether a particular connection is still live — for example, after a silo crash where the hub's `OnDisconnectedAsync` never completed and the grain still holds stale observer references. Instead of relying solely on the periodic cleanup ping, you can proactively query a stored connection ID at startup or on-demand:
 
 ```cs
 var connectionGrain = grainFactory.GetGrain<IConnectionGrain>($"myhubs.myhub/{connectionId}");

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Design](#design)
   * [Graceful Disconnection](#graceful-disconnection)
   * [Silo Crash](#silo-crash)
+  * [Checking for Active Observers](#checking-for-active-observers)
 - [Architecture](#architecture)
   * [Sending from the within the Orleans cluster](#sending-from-the-within-the-orleans-cluster-1)
   * [Sending from an external client](#sending-from-an-external-client-1)
@@ -288,6 +289,18 @@ If you would like to customise the cleanup period, use the `GrainCleanupPeriod` 
 ```cs
 .AddSignalRBackplane(x => x.GrainCleanupPeriod = TimeSpan.FromHours(1))
 ```
+
+## Checking for Active Observers
+The `IConnectionGrain` interface exposes a `HasObserversAsync()` method that returns `true` if the connection grain currently has at least one active observer (i.e. a hub is subscribed to it), or `false` if the grain has no observers.
+
+This is useful when you need to determine from outside the grain whether a particular connection is still live — for example, after a silo crash where `UnregisterConnectionAsync` was never called. Instead of relying solely on the periodic cleanup ping, you can proactively query a stored connection ID at startup or on-demand:
+
+```cs
+var connectionGrain = grainFactory.GetGrain<IConnectionGrain>($"myhubs.myhub/{connectionId}");
+bool isAlive = await connectionGrain.HasObserversAsync();
+```
+
+If `HasObserversAsync()` returns `false`, the connection is no longer registered with any hub and any locally-held reference to it can be discarded immediately.
 
 # Architecture
 ## Sending from the within the Orleans cluster

--- a/samples/Shared/Shared.csproj
+++ b/samples/Shared/Shared.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
   </ItemGroup>
 
 

--- a/src/UFX.Orleans.SignalRBackplane.Abstractions/IConnectionGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane.Abstractions/IConnectionGrain.cs
@@ -1,6 +1,13 @@
-﻿namespace UFX.Orleans.SignalRBackplane.Abstractions;
+namespace UFX.Orleans.SignalRBackplane.Abstractions;
 
 public interface IConnectionGrain : IGrainWithStringKey
 {
     Task SendConnectionAsync(string methodName, object?[] args);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this grain has at least one live observer (i.e. the
+    /// underlying SignalR connection is still active on some silo). Returns <see langword="false"/>
+    /// when the connection has disconnected or its silo has crashed and the observer set is empty.
+    /// </summary>
+    Task<bool> HasObserversAsync();
 }

--- a/src/UFX.Orleans.SignalRBackplane.Abstractions/IConnectionGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane.Abstractions/IConnectionGrain.cs
@@ -5,9 +5,14 @@ public interface IConnectionGrain : IGrainWithStringKey
     Task SendConnectionAsync(string methodName, object?[] args);
 
     /// <summary>
-    /// Returns <see langword="true"/> if this grain has at least one live observer (i.e. the
-    /// underlying SignalR connection is still active on some silo). Returns <see langword="false"/>
-    /// when the connection has disconnected or its silo has crashed and the observer set is empty.
+    /// Actively pings all registered observers, removes any that fail to respond, then returns
+    /// <see langword="true"/> if at least one reachable observer remains, or <see langword="false"/>
+    /// if all observers were defunct (or there were none to begin with).
+    /// When <see langword="false"/> is returned the grain also deactivates itself.
     /// </summary>
+    /// <remarks>
+    /// Because this method contacts remote observer references it has similar cost to a regular
+    /// grain-to-grain call for each registered observer. Avoid calling it in tight loops.
+    /// </remarks>
     Task<bool> HasObserversAsync();
 }

--- a/src/UFX.Orleans.SignalRBackplane.Abstractions/UFX.Orleans.SignalRBackplane.Abstractions.csproj
+++ b/src/UFX.Orleans.SignalRBackplane.Abstractions/UFX.Orleans.SignalRBackplane.Abstractions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UFX.Orleans.SignalRBackplane.Client/UFX.Orleans.SignalRBackplane.Client.csproj
+++ b/src/UFX.Orleans.SignalRBackplane.Client/UFX.Orleans.SignalRBackplane.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
@@ -34,6 +34,9 @@ internal class ConnectionGrain : SignalrBaseGrain, IConnectionGrain, IConnection
     public Task RemoveFromGroupAsync(string groupName)
         => InformObserversAsync(observer => observer.RemoveFromGroupAsync(EntityId, groupName));
 
-    public Task<bool> HasObserversAsync()
-        => Task.FromResult(HasObservers);
+    public async Task<bool> HasObserversAsync()
+    {
+        await PruneObserversAsync();
+        return HasObservers;
+    }
 }

--- a/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/ConnectionGrain.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 using UFX.Orleans.SignalRBackplane.Abstractions;
@@ -14,7 +14,8 @@ internal interface IConnectionGrainInternal : ISignalrGrain
 internal class ConnectionGrain : SignalrBaseGrain, IConnectionGrain, IConnectionGrainInternal
 {
     public ConnectionGrain(
-        [PersistentState(Constants.StateName, Constants.StorageName)] IPersistentState<SubscriptionState> persistedSubs,
+        [PersistentState(Constants.StateName, Constants.StorageName)]
+        IPersistentState<SubscriptionState> persistedSubs,
         IGrainContext grainContext,
         IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
@@ -24,7 +25,7 @@ internal class ConnectionGrain : SignalrBaseGrain, IConnectionGrain, IConnection
     {
     }
 
-    public Task SendConnectionAsync(string methodName, object?[] args) 
+    public Task SendConnectionAsync(string methodName, object?[] args)
         => InformObserversAsync(observer => observer.SendConnectionAsync(EntityId, methodName, args));
 
     public Task AddToGroupAsync(string groupName)
@@ -32,4 +33,7 @@ internal class ConnectionGrain : SignalrBaseGrain, IConnectionGrain, IConnection
 
     public Task RemoveFromGroupAsync(string groupName)
         => InformObserversAsync(observer => observer.RemoveFromGroupAsync(EntityId, groupName));
+
+    public Task<bool> HasObserversAsync()
+        => Task.FromResult(HasObservers);
 }

--- a/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
@@ -34,7 +34,9 @@ internal abstract class SignalrBaseGrain : IGrainBase, ISignalrGrain, IRemindabl
     private HashSet<IHubLifetimeManagerGrainObserver> _observers = new();
 
     /// <summary>
-    /// Returns <see langword="true"/> if this grain currently has at least one live observer.
+    /// Returns <see langword="true"/> if the in-memory observer set is non-empty.
+    /// Note: the set may still contain stale observer references that have not yet been pruned
+    /// (pruning happens on <see cref="PruneObserversAsync"/> or during notification failures).
     /// </summary>
     protected bool HasObservers => _observers.Count > 0;
 

--- a/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 
@@ -23,18 +23,23 @@ internal abstract class SignalrBaseGrain : IGrainBase, ISignalrGrain, IRemindabl
     /// The EntityId of the grain. This is the connectionId for a connection grain, the userId for a user grain, the group name for a group grain and the hub name for a hub grain.
     /// </summary>
     protected readonly string EntityId;
-    
+
     private const string PingReminderName = nameof(PingReminderName);
 
     private readonly IPersistentState<SubscriptionState> _persistedSubs;
     private readonly IReminderResolver _reminderResolver;
     private readonly ILogger<SignalrBaseGrain> _logger;
     private readonly TimeSpan _grainCleanupPeriod;
-    
+
     private HashSet<IHubLifetimeManagerGrainObserver> _observers = new();
 
+    /// <summary>
+    /// Returns <see langword="true"/> if this grain currently has at least one live observer.
+    /// </summary>
+    protected bool HasObservers => _observers.Count > 0;
+
     protected SignalrBaseGrain(
-        IPersistentState<SubscriptionState> persistedSubs, 
+        IPersistentState<SubscriptionState> persistedSubs,
         IGrainContext grainContext,
         IReminderResolver reminderResolver,
         IOptions<SignalrOrleansOptions> options,
@@ -61,7 +66,7 @@ internal abstract class SignalrBaseGrain : IGrainBase, ISignalrGrain, IRemindabl
         _observers = _persistedSubs.State.Observers;
     }
 
-    public Task SubscribeAsync(IHubLifetimeManagerGrainObserver observer) 
+    public Task SubscribeAsync(IHubLifetimeManagerGrainObserver observer)
         => RunActionAndUpdateStateAsync(() => _observers.Add(observer));
 
     public Task UnsubscribeAsync(IHubLifetimeManagerGrainObserver observer)
@@ -75,7 +80,7 @@ internal abstract class SignalrBaseGrain : IGrainBase, ISignalrGrain, IRemindabl
         }
     }
 
-    protected Task InformObserversAsync(Func<IHubLifetimeManagerGrainObserver, Task> notificationCallback) 
+    protected Task InformObserversAsync(Func<IHubLifetimeManagerGrainObserver, Task> notificationCallback)
         => RunActionAndUpdateStateAsync(() => NotifyAllObserversAsync(notificationCallback));
 
     async Task NotifyAllObserversAsync(Func<IHubLifetimeManagerGrainObserver, Task> notification)

--- a/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
+++ b/src/UFX.Orleans.SignalRBackplane/Grains/SignalrBaseGrain.cs
@@ -72,11 +72,14 @@ internal abstract class SignalrBaseGrain : IGrainBase, ISignalrGrain, IRemindabl
     public Task UnsubscribeAsync(IHubLifetimeManagerGrainObserver observer)
         => RunActionAndUpdateStateAsync(() => _observers.Remove(observer));
 
+    protected Task PruneObserversAsync()
+        => RunActionAndUpdateStateAsync(() => NotifyAllObserversAsync(observer => observer.PingAsync()), deactivateOnIdle: true);
+
     public async Task ReceiveReminder(string reminderName, TickStatus status)
     {
         if (reminderName == PingReminderName)
         {
-            await RunActionAndUpdateStateAsync(() => NotifyAllObserversAsync(observer => observer.PingAsync()), deactivateOnIdle: true);
+            await PruneObserversAsync();
         }
     }
 

--- a/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
+++ b/src/UFX.Orleans.SignalRBackplane/UFX.Orleans.SignalRBackplane.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UFX.Orleans.SignalRBackplane.Tests/ConnectionGrainTests.cs
+++ b/tests/UFX.Orleans.SignalRBackplane.Tests/ConnectionGrainTests.cs
@@ -1,0 +1,95 @@
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Runtime;
+using UFX.Orleans.SignalRBackplane.Grains;
+
+namespace UFX.Orleans.SignalRBackplane.Tests;
+
+public class ConnectionGrainTests
+{
+    private static ConnectionGrain CreateGrain(
+        IPersistentState<SubscriptionState> persistedSubs,
+        IGrainContext grainContext,
+        IReminderResolver? reminderResolver = null)
+    {
+        var resolver = reminderResolver ?? A.Fake<IReminderResolver>();
+        A.CallTo(() => resolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored))
+            .Returns<IGrainReminder?>(null!);
+        return new ConnectionGrain(
+            persistedSubs,
+            grainContext,
+            resolver,
+            A.Fake<IOptions<SignalrOrleansOptions>>(),
+            A.Fake<ILogger<ConnectionGrain>>());
+    }
+
+    [Fact]
+    public async Task HasObserversAsync_ReturnsFalse_WhenNoObserversSubscribed()
+    {
+        // Arrange
+        var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+        var grainContext = A.Fake<IGrainContext>();
+        A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "hub/conn1"));
+
+        var grain = CreateGrain(persistentState, grainContext);
+
+        // Act
+        var result = await grain.HasObserversAsync();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HasObserversAsync_ReturnsTrue_WhenObserverIsReachable()
+    {
+        // Arrange
+        var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+        var grainContext = A.Fake<IGrainContext>();
+        A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "hub/conn1"));
+        var reminderResolver = A.Fake<IReminderResolver>();
+        A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored))
+            .Returns<IGrainReminder?>(null!);
+
+        var grain = CreateGrain(persistentState, grainContext, reminderResolver);
+
+        var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+        // PingAsync succeeds by default — observer is reachable
+        await grain.SubscribeAsync(observer);
+
+        // Act
+        var result = await grain.HasObserversAsync();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HasObserversAsync_ReturnsFalse_AndPrunesObserver_WhenAllObserversAreDefunct()
+    {
+        // Arrange
+        var persistentState = A.Fake<IPersistentState<SubscriptionState>>();
+        var grainContext = A.Fake<IGrainContext>();
+        A.CallTo(() => grainContext.GrainId).Returns(GrainId.Create("test", "hub/conn1"));
+        var reminderResolver = A.Fake<IReminderResolver>();
+        A.CallTo(() => reminderResolver.GetReminder(A<IGrainBase>.Ignored, A<string>.Ignored))
+            .Returns<IGrainReminder?>(null!);
+
+        var grain = CreateGrain(persistentState, grainContext, reminderResolver);
+
+        var observer = A.Fake<IHubLifetimeManagerGrainObserver>();
+        await grain.SubscribeAsync(observer);
+
+        // Simulate a defunct observer — PingAsync throws
+        A.CallTo(() => observer.PingAsync()).Throws(new Exception("Observer unreachable"));
+
+        // Act
+        var result = await grain.HasObserversAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        persistentState.State.Observers.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `HasObserversAsync()` to `IConnectionGrain`, allowing callers to check at any point whether a connection grain currently has any live observers — i.e. whether the underlying SignalR connection is still active on some silo.

## Motivation

When a silo crashes, `OnDisconnectedAsync` never fires for connections that were hosted on it. Any external component that tracks active connections using grain storage will therefore have stale entries after the crash.

Previously the only way to detect this was an application-level heartbeat: the client pings periodically, and entries whose last-seen timestamp is too old are considered dead. This requires:
- A client-side timer
- A `LastSeen` field on the tracked state
- A server-side prune timer

`HasObserversAsync()` removes all of that. A caller can simply check the backplane on grain activation: if the connection grain has no observers the connection is dead and the entry can be dropped immediately. The `GrainCleanupPeriod` reminder already handles eventual self-cleanup of the connection grain itself.

## Changes

- **`IConnectionGrain`** (Abstractions) — adds `Task<bool> HasObserversAsync()`
- **`SignalrBaseGrain`** — adds `protected bool HasObservers => _observers.Count > 0;`
- **`ConnectionGrain`** — implements `HasObserversAsync()` returning `HasObservers`

## Version

Also bumps all Orleans package references from `10.0.1` → `10.1.0`. Tag `v10.1.0` on main after merge to publish.